### PR TITLE
Fix easeIn for when endValue < startValue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,12 +36,12 @@ export const easeIn = ({
   startValue = 0,
 }: EaseInOptions): juiceFn => {
   const speedParameter =
-    Math.log(1 - startValue + Math.abs(endValue)) / duration
+    Math.log(1 + Math.abs(startValue - endValue)) / duration
 
   const modifier = endValue < startValue ? -1 : 1
 
   return (t) => {
-    return (startValue - 1 + Math.E ** (t * speedParameter)) * modifier
+    return startValue + (Math.E ** (t * speedParameter) - 1) * modifier
   }
 }
 

--- a/test.ts
+++ b/test.ts
@@ -106,6 +106,24 @@ test('easeIn - negative endValue', (t) => {
   }, expectedValues.length)
 })
 
+test('easeIn - endValue < startValue', (t) => {
+  const getX = juice.easeIn({
+    startValue: 60,
+    endValue: 20,
+    duration,
+  })
+  const expectedValues = [
+    60 - 0,
+    60 - 1.1016324782757847,
+    60 - 3.416859073743617,
+    60 - 8.282614481346688,
+    60 - 18.508644077311324,
+  ]
+  times((index) => {
+    t.is(getX(index), expectedValues[index])
+  }, expectedValues.length)
+})
+
 test('parabola', (t) => {
   const getX = juice.parabola({
     height: 20,

--- a/test.ts
+++ b/test.ts
@@ -95,7 +95,7 @@ test('easeIn - negative endValue', (t) => {
     duration,
   })
   const expectedValues = [
-    -0,
+    0,
     -1.1016324782757847,
     -3.416859073743617,
     -8.282614481346688,


### PR DESCRIPTION
Using easeIn with a lower endValue than startValue caused speedParameter to become NaN.

Math.abs should be used on the difference between the two, not on endValue alone.

Modifier should not be applied to startValue.